### PR TITLE
Add PDO example and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Never commit these!
+.env
+.env.local
+.env.production

--- a/README.md
+++ b/README.md
@@ -45,7 +45,25 @@ STRIPE_API_KEY=sk_test_your_stripe_key
 GOOGLE_MAPS_API_KEY=your_google_maps_key
 ```
 
-### 3. Secure Your Setup
+### 3. Create `my_db.php`
+
+```php
+<?php
+// my_db.php - uses environment variables for PDO
+$dsn = sprintf(
+    'mysql:host=%s;dbname=%s;charset=utf8mb4',
+    getenv('DB_HOST'),
+    getenv('DB_NAME')
+);
+$pdo = new PDO($dsn, getenv('DB_USER'), getenv('DB_PASS'), [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+]);
+
+$my_db = getenv('DB_NAME'); // used by example scripts
+```
+
+### 4. Secure Your Setup
 
 **Add to `.gitignore`:**
 ```gitignore

--- a/my_db.php
+++ b/my_db.php
@@ -1,0 +1,10 @@
+<?php
+// Simple PDO connection using environment variables
+$dsn = sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4', getenv('DB_HOST'), getenv('DB_NAME'));
+$pdo = new PDO($dsn, getenv('DB_USER'), getenv('DB_PASS'), [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+]);
+
+// Database name variable used by examples
+$my_db = getenv('DB_NAME');


### PR DESCRIPTION
## Summary
- show how to connect to the DB via environment vars
- document the `my_db.php` example in README
- ignore credential files by default

## Testing
- `php -l my_db.php` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a61903b188327a092ae6939cd418f